### PR TITLE
Fix check of object in swagger

### DIFF
--- a/swagger_unittest/swagger_parser/swagger_parser.py
+++ b/swagger_unittest/swagger_parser/swagger_parser.py
@@ -147,8 +147,9 @@ class SwaggerParser(object):
                     (isinstance(value, (six.text_type, six.string_types,)) and
                      value.lower() in ['true', 'false'])
                     )
-        else:
-            return False
+        elif type_def == 'object':
+            return isinstance(value, dict)
+        return False
 
     def get_example_from_prop_spec(self, prop_spec):
         """Return an example value from a property specification.

--- a/tests/swagger_parser/test_swagger_parser.py
+++ b/tests/swagger_parser/test_swagger_parser.py
@@ -67,6 +67,9 @@ def test_check_type(swagger_parser):
     assert not swagger_parser.check_type(False, 'string')
     assert swagger_parser.check_type(False, 'boolean')
 
+    # Test object
+    assert swagger_parser.check_type({'a': 'test'}, 'object')
+    assert not swagger_parser.check_type(1, 'object')
     # Test other
     assert not swagger_parser.check_type(swagger_parser, 'string')
 


### PR DESCRIPTION
Swagger type object is general dict. At the moment such object was not supported.

In case the swagger type is object it should return True in case the type is Dictionary. Any dictionary complies with object type..

I need it for updated swagger that I have just created in new PR